### PR TITLE
Allow chaining of queries

### DIFF
--- a/lib/triton/query_builder.ex
+++ b/lib/triton/query_builder.ex
@@ -1,10 +1,16 @@
 defmodule Triton.QueryBuilder do
   def build_query(type, module, value) do
     quote do
-      [
-        { unquote(type), unquote(value) }
-        | Triton.QueryBuilder.query_list(unquote(module))
-      ]
+      existing_query = Triton.QueryBuilder.query_list(unquote(module))
+      existing_type = unquote(type)
+
+      case Keyword.get(existing_query, existing_type) do
+        # Existing query don't exist yet, just use old logic
+        nil -> [ { existing_type, unquote(value)} | existing_query ]
+        existing_value -> 
+          new_value = Keyword.merge(existing_value, unquote(value))
+          Keyword.merge(existing_query, [ {existing_type, new_value} ])
+      end
     end
   end
 


### PR DESCRIPTION
Allows chaining of queries, such as `|> where(val1: a) |> where(val2: b)` which will act the same as a `|> where(val1: a, val2: b)` query

This has undefined behavior if you use queries with multiple of the same key.